### PR TITLE
Add more tests.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,10 @@ environment:
       OUTPUT: "py35.exe"
     - PYTHON: "C:\\Python35-x64"
       OUTPUT: "py35-64.exe"
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python36"
       OUTPUT: "py36.exe"
+    - PYTHON: "C:\\Python36-x64"
+      OUTPUT: "py36-64.exe"
 
 init:
   - SET PROJDIR=%cd%
@@ -24,19 +26,22 @@ init:
   - cd %PROJDIR%
 
 build_script:
-  - python list_modules.py py.py
-  - python -m PyInstaller --onefile py.py --upx-dir C:\\u\\upx394w\\upx.exe --exclude-module FixTk --exclude-module tcl --exclude-module tk --exclude-module _tkinter --exclude-module tkinter --exclude-module Tkinter
-  - cp dist\py.exe %OUTPUT%
+  - python modules_pyexe.py pyexe.py
+  # Save the artifact immediately
+  - appveyor PushArtifact pyexe.py
+  - python -m PyInstaller --onefile pyexe.py --upx-dir C:\\u\\upx394w\\upx.exe --exclude-module FixTk --exclude-module tcl --exclude-module tk --exclude-module _tkinter --exclude-module tkinter --exclude-module Tkinter
+  - cp dist\pyexe.exe %OUTPUT%
+  # Save the artifact immediately
+  - appveyor PushArtifact %OUTPUT%
 
 test_script:
   - SET PATH=%ORIGPATH%
-  - "cd %PROJDIR%\\tests"
   - pip install pytest
-  - "python -m pytest --exe=..\\%OUTPUT%"
+  - "python -m pytest -l --exe=%OUTPUT%"
 
-artifacts:
-  - path: py.py
-  - path: "%OUTPUT%"
+# artifacts:
+#   - path: pyexe.py
+#   - path: "%OUTPUT%"
 
 deploy:
   - provider: GitHub

--- a/modules_pyexe.py
+++ b/modules_pyexe.py
@@ -24,7 +24,7 @@ all = [item for item in all if '-' not in item]
 # Modules we know we can't work with or are completely pointless
 Exclude = [
     # our own code
-    'py', 'pymodules',
+    'pyexe', 'modules_pyexe', 'modules_pyexe_list',
     # installers
     'py2exe',
     'PyInstaller', 'pefile', 'macholib', 'dis3', 'future', 'altgraph',

--- a/pyexe.py
+++ b/pyexe.py
@@ -12,8 +12,8 @@ if not AllModules and sys.argv[:2][-1] != '--all':
     pass
 else:
     # IMPORT ALL MODULES
-    import pymodules  # noqa
-    print(dir(pymodules))  # for installers to include submodules
+    import modules_pyexe_list  # noqa, this is the output of modules_pyexe
+    print(dir(modules_pyexe_list))  # for installers to include submodules
     # END IMPORT ALL MODULES
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ from py_version import Version, Description
 
 setup(
     console=[{
-        'script': 'py.py',
+        'script': 'pyexe.py',
         'other_resources': [(
             py2exe.resources.VersionInfo.RT_VERSION, 1, py2exe.resources.VersionInfo.Version(
                 version=Version,

--- a/tests/test_pyexe.py
+++ b/tests/test_pyexe.py
@@ -16,6 +16,13 @@ def runPyExe(exepath, options=[], input=''):
     return out, err
 
 
+def testVersion(exepath):
+    out, err = runPyExe(exepath, ['--version'])
+    assert out.startswith('Stand-Alone Python Interpreter')
+    out, err = runPyExe(exepath, ['-V'])
+    assert out.startswith('Stand-Alone Python Interpreter')
+
+
 def testDirectCommand(exepath):
     out, err = runPyExe(exepath, ['-c', 'print("This is a test")'])
     assert out.startswith('This is a test')
@@ -27,15 +34,31 @@ def testDirectCommandImport(exepath):
     assert out.startswith('{"test": "value"}')
 
 
-def testVersion(exepath):
-    out, err = runPyExe(exepath, ['--version'])
-    assert out.startswith('Stand-Alone Python Interpreter')
-    out, err = runPyExe(exepath, ['-V'])
-    assert out.startswith('Stand-Alone Python Interpreter')
+def testImportPsutil(exepath):
+    out, err = runPyExe(exepath, [
+        '-c', """import psutil;print(repr(psutil.cpu_times()))"""])
+    assert 'scputimes' in out
+    out, err = runPyExe(exepath, [
+        '-c', """import psutil;print(repr(psutil.net_connections()))"""])
+    assert 'raddr' in out
+
+
+def testImportSix(exepath):
+    out, err = runPyExe(exepath, [
+        '-c', """import six;print(six.callable(six.BytesIO))"""])
+    assert 'True' in out
+
+
+def testImportPywin32(exepath):
+    out, err = runPyExe(exepath, input="""import win32con
+import win32file
+print('%r' % [
+  win32file.GetFileAttributes('.'), win32con.FILE_ATTRIBUTE_DIRECTORY])
+""")
+    assert '16, 16' in out
 
 
 # Add tests for:
-#  importing psutil, six, pywin32
 #  command line options:
 #    -i / PYTHONINSPECT
 #    -h / --help /?
@@ -46,3 +69,4 @@ def testVersion(exepath):
 #  with source file
 #    -x
 #  stdin
+#  pip install serial and then use it


### PR DESCRIPTION
Add Python 3.6 32 bit.

Rename py.py to pyexe.py.  This avoids conflicting with a module called 'py', allowing easier use in the root directory.