### PR TITLE
Document why we aren't using runpy.run_path.

### DIFF
--- a/py_version.py
+++ b/py_version.py
@@ -2,5 +2,5 @@
 
 import sys
 
-Version = sys.version.split()[0] + '.12'
+Version = sys.version.split()[0] + '.13'
 Description = 'Stand-Alone Python Interpreter'

--- a/tests/sample_multiprocessing.py
+++ b/tests/sample_multiprocessing.py
@@ -18,7 +18,6 @@ def calculateSum(idx, values, weight, results):
 
 
 if __name__ == '__main__':
-    print(sys.executable)
     results = multiprocessing.Array('d', range(numJobs))
     multiprocessing.set_executable(sys.executable)
     jobs = []

--- a/tests/sample_no_header.py
+++ b/tests/sample_no_header.py
@@ -1,0 +1,1 @@
+print('no header line')

--- a/tests/sample_skip_header.py
+++ b/tests/sample_skip_header.py
@@ -1,0 +1,2 @@
+This line must be skipped
+print('skipped header')

--- a/tests/sample_zipapp/__main__.py
+++ b/tests/sample_zipapp/__main__.py
@@ -1,6 +1,3 @@
-import sys
-print(sys.argv)
-print(sys.path)
 from samplemod import part1
 from samplemod import part2
 

--- a/tests/test_pyexe.py
+++ b/tests/test_pyexe.py
@@ -172,10 +172,17 @@ def testZipApp(exepath):
     assert '15' in out
 
 
+def testSkipHeader(exepath):
+    out, err = runPyExe(exepath, ['sample_skip_header.py'])
+    assert 'SyntaxError: invalid syntax' in err
+    out, err = runPyExe(exepath, ['-x', 'sample_skip_header.py'])
+    assert 'skipped header' in out
+    out, err = runPyExe(exepath, ['sample_no_header.py'])
+    assert 'no header' in out
+
+
 # Add tests for:
 #  command line options:
 #    -u / PYTHONUNBUFFERED
 #    -S
 #    -E
-#  with source file
-#    -x


### PR DESCRIPTION
Add tests for skipping header lines.