### PR TITLE
Install the latest point version of python.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Set program icon.
 - When running a Python program, the globals are closer to native Python.
 - Update to setuptools 39.1.0.
+- Update to Python 2.7.15, 3.5.4, 3.6.5.
 
 ### Bug Fixes
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,33 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
+      INSTALL_OPTIONS: 2.7 --min=15
       OUTPUT: "py27.exe"
+      ALTPYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python27-x64"
+      INSTALL_OPTIONS: 2.7 --min=15 --64
       OUTPUT: "py27-64.exe"
+      ALTPYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python35"
+      INSTALL_OPTIONS: 3.5 --min=4
       OUTPUT: "py35.exe"
+      ALTPYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python35-x64"
+      INSTALL_OPTIONS: 3.5 --min=4 --64
       OUTPUT: "py35-64.exe"
+      ALTPYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python36"
+      INSTALL_OPTIONS: 3.6 --min=5
       OUTPUT: "py36.exe"
+      ALTPYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python36-x64"
+      INSTALL_OPTIONS: 3.6 --min=5 --64
       OUTPUT: "py36-64.exe"
+      ALTPYTHON: "C:\\Python36"
 
 init:
   - SET PROJDIR=%cd%
   - SET ORIGPATH=%PATH%
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - python -m pip install --upgrade pip
-  - python -m pip install --upgrade setuptools
-  - python -m pip install pywin32 psutil six setuptools
-  - python -m pip install pyinstaller
-  # Remove the site module hook from PyInstaller; we need the site module as is
-  - "del /q %PYTHON%\\Lib\\site-packages\\PyInstaller\\hooks\\pre_find_module_path\\hook-site.*"
-  - "del /q /s %PYTHON%\\Lib\\site-packages\\PyInstaller\\hooks\\pre_find_module_path\\__pycache__"
   - mkdir c:\u
   - cd c:\u
   - curl -L -O "https://github.com/upx/upx/releases/download/v3.94/upx394w.zip"
@@ -31,13 +35,34 @@ init:
   - cd %PROJDIR%
 
 build_script:
+  # Upgrade the appveyor python version
+  - "SET PATH=%ALTPYTHON%;%ALTPYTHON%\\Scripts;%ORIGPATH%"
+  - python -m pip install --upgrade requests
+  - "python install_python.py %INSTALL_OPTIONS% --out=%PYTHON% --force"
+  - del /S /Q %PYTHON%\*.pyc >NUL
+  - del /S /Q %PYTHON%\*.pyo >NUL
+  # Use the specific python version for building
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%ORIGPATH%"
+  - python -m pip install --upgrade pip
+  - python -m pip install --upgrade setuptools
+  - python -m pip install --upgrade pywin32 psutil six setuptools
+  # Generate the list of modules we need to import
+  - del /S /Q %PYTHON%\*.pyc >NUL
+  - del /S /Q %PYTHON%\*.pyo >NUL
+  - python modules_pyexe.py pyexe.py
+  # Install PyInstaller
+  - python -m pip install pyinstaller
+  # Remove the site module hook from PyInstaller; we need the site module as is
+  - "del /q %PYTHON%\\Lib\\site-packages\\PyInstaller\\hooks\\pre_find_module_path\\hook-site.*"
+  - "del /q /s %PYTHON%\\Lib\\site-packages\\PyInstaller\\hooks\\pre_find_module_path\\__pycache__"
   # Copy a build hook to PyInstaller to include the cacerts.pem file for pip.
   - "copy hooks\\hook*.* %PYTHON%\\Lib\\site-packages\\PyInstaller\\hooks\\."
   # Replace the multiprocessing loader hook
   - "copy hooks\\pyi_rth*.* %PYTHON%\\Lib\\site-packages\\PyInstaller\\loader\\rthooks\\."
   # Replace the stage 3 importer
   - "copy hooks\\pyimod03_importers.py %PYTHON%\\Lib\\site-packages\\PyInstaller\\loader\\."
-  - python modules_pyexe.py pyexe.py
+  - del /S /Q %PYTHON%\*.pyc >NUL
+  - del /S /Q %PYTHON%\*.pyo >NUL
   # Save the artifact immediately
   - appveyor PushArtifact pyexe.py
   - "python -m PyInstaller --onefile pyexe.py --upx-dir C:\\u\\upx394w\\upx.exe --exclude-module FixTk --exclude-module tcl --exclude-module tk --exclude-module _tkinter --exclude-module tkinter --exclude-module Tkinter --runtime-hook hooks\\rth_subprocess.py --icon %PYTHON%\\pythonw.exe"

--- a/install_python.py
+++ b/install_python.py
@@ -1,0 +1,113 @@
+import os
+import requests
+import subprocess
+import sys
+
+if __name__ == '__main__':  # noqa
+    dest = '.'
+    instdest = None
+    force = False
+    help = False
+    is64 = False
+    keep = False
+    minpoint = 0
+    remove = False
+    version = None
+    for arg in sys.argv[1:]:
+        if arg.startswith('-'):
+            if arg in ('-f', '--force'):
+                force = True
+            elif arg in ('-k', '--keep'):
+                keep = True
+            elif arg.startswith('--inst='):
+                instdest = arg.split('=', 1)[1]
+            elif arg.startswith('--min='):
+                minpoint = int(arg.split('=', 1)[1])
+            elif arg.startswith('--out='):
+                dest = arg.split('=', 1)[1]
+            elif arg in ('-r', '--remove'):
+                remove = True
+            elif arg == '--32':
+                is64 = False
+            elif arg == '--64':
+                is64 = True
+            else:
+                help = True
+        elif not version:
+            version = arg
+        else:
+            help = True
+    if help or not version:
+        print("""Install the latest revision of a version of python.
+
+Syntax: install_python.py (version) [--32|--64] [--out=(destination directory)]
+        [--inst=(installation directory)] [--force]
+        [--min=(minimum point release)] [--keep] [--remove]
+
+Specify just the major and minor version, such as 2.7 or 3.6.
+--force will overwrite an existing installation file.
+--keep keeps the install file.
+--remove first uninstalls the specified version of python.""")
+        sys.exit(0)
+    baseurl = 'https://www.python.org/ftp/python/'
+    versionList = requests.get(baseurl).text
+    versionList = [part.split('"')[0] for part in versionList.split('<a href="')[1:]]
+    versionList = sorted([(int(ver[len(version) + 1:].strip('/')), ver)
+                          for ver in versionList if ver.startswith(version + '.')],
+                         reverse=True)
+    for subver, ver in versionList:
+        if subver < minpoint:
+            continue
+        url = baseurl + ver + 'python-' + version + '.' + str(subver) + (
+            '' if not is64 else ('.amd64' if version.startswith('2') else '-amd64')) + (
+            '.msi' if version.startswith('2') else '.exe')
+        try:
+            response = requests.get(url).content
+            if len(response) < 1000000:
+                continue
+            break
+        except Exception:
+            continue
+    if len(response) < 1000000:
+        raise Exception('Failed to find install file')
+    print('Size: %d, url: %s' % (len(response), url))
+    if instdest is None:
+        instdest = os.path.split(dest)[0]
+    if not os.path.exists(instdest):
+        os.makedirs(instdest)
+    installer = os.path.join(instdest, url.rsplit('/', 1)[-1])
+    if os.path.exists(installer) and not force:
+        raise Exception('Path already exists: %s' % installer)
+    open(installer, 'wb').write(response)
+    if installer.endswith('.msi'):
+        uncmd = ['msiexec', '/uninstall', installer, '/quiet', '/norestart']
+        cmd = ['msiexec', '/i', installer, '/quiet', '/norestart']
+        altcmd = ['msiexec', '/fa', installer, '/quiet', '/norestart']
+    else:
+        uncmd = [installer, '/quiet', '/uninstall']
+        cmd = [installer, '/quiet']
+        altcmd = [installer, '/quiet', '/repair']
+    cmdopts = [
+        'TargetDir=' + dest, 'AssociateFiles=0', 'CompileAll=0',
+        'PrependPath=0', 'Shortcuts=0', 'Include_doc=0', 'Include_dev=0',
+        'Include_debug=0', 'Include_exe=1', 'Include_launcher=0',
+        'InstallLauncherAllUsers=0', 'Include_lib=1', 'Include_symbols=0',
+        'Include_tcltk=0', 'Include_test=0', 'Include_tools=0',
+        'SimpleInstall=1']
+    if remove:
+        print('Remove: ' + ' '.join(uncmd))
+        try:
+            subprocess.check_call(uncmd)
+        except Exception:
+            pass
+    print('Install: ' + ' '.join(cmd + cmdopts))
+    try:
+        subprocess.check_call(cmd + cmdopts)
+    except Exception:
+        pass
+    if not os.path.exists(os.path.join(dest, 'python.exe')):
+        print('Update ' + ' '.join(altcmd + cmdopts))
+        subprocess.check_call(altcmd + cmdopts)
+    print('Done')
+    if not keep:
+        os.unlink(installer)


### PR DESCRIPTION
Reorder when pyinstaller is installed.  This helps avoid pulling in some libraries that aren't technically needed.

Resolves #16.