### PR TITLE
Add the executable path to the system paths.

### DIFF
--- a/pyexe.py
+++ b/pyexe.py
@@ -317,6 +317,10 @@ PYTHONCASEOK : ignore case in 'import' statements (Windows).""")
 if PrintVersion:
     print_version(PrintVersion)
     sys.exit(0)
+# Explicitly add the path of the current executable to the system paths.
+# Installed Python always incldues this path, but PyInstaller changes it to the
+# expanded path.
+sys.path[0:0] = [os.path.abspath(os.path.dirname(sys.executable))]
 if UseEnvironment:
     if os.environ.get('PYTHONDONTWRITEBYTECODE'):
         sys.dont_write_bytecode = True

--- a/pyexe.py
+++ b/pyexe.py
@@ -317,10 +317,13 @@ PYTHONCASEOK : ignore case in 'import' statements (Windows).""")
 if PrintVersion:
     print_version(PrintVersion)
     sys.exit(0)
-# Explicitly add the path of the current executable to the system paths.
-# Installed Python always incldues this path, but PyInstaller changes it to the
-# expanded path.
-sys.path[0:0] = [os.path.abspath(os.path.dirname(sys.executable))]
+# Explicitly add the path of the current executable to the system paths and its
+# subpath of Lib\site-packages.  Installed Python always includes these paths,
+# but PyInstaller changes them to the expanded paths.
+sys.path[0:0] = [
+    os.path.abspath(os.path.dirname(sys.executable)),
+    os.path.abspath(os.path.join(os.path.dirname(sys.executable), 'Lib', 'site-packages'))
+]
 if UseEnvironment:
     if os.environ.get('PYTHONDONTWRITEBYTECODE'):
         sys.dont_write_bytecode = True

--- a/tests/test_pyexe.py
+++ b/tests/test_pyexe.py
@@ -499,10 +499,26 @@ def testPythonCaseOK(exepath, pyversion):
 
 
 def testImportFromExePath(exepath):
-    modpath = os.path.join(os.path.dirname(exepath), 'mod_abc.py')
+    modpath = os.path.join(os.path.dirname(exepath), 'mod_exepath.py')
     try:
         open(modpath, 'wt').write('foo = "bar"')
-        out, err = runPyExe(exepath, ['-c', 'import mod_abc;print(mod_abc.foo)'])
+        out, err = runPyExe(exepath, ['-c', 'import mod_exepath;print(mod_exepath.foo)'])
         assert 'bar' in out
     finally:
         os.unlink(modpath)
+    sitepath = os.path.join(os.path.dirname(exepath), 'Lib', 'site-packages')
+    modpath = os.path.join(sitepath, 'mod_libsite.py')
+    try:
+        os.makedirs(sitepath)
+    except Exception:
+        pass
+    try:
+        open(modpath, 'wt').write('foo = "baz"')
+        out, err = runPyExe(exepath, ['-c', 'import mod_libsite;print(mod_libsite.foo)'])
+        assert 'baz' in out
+    finally:
+        os.unlink(modpath)
+        try:
+            os.removedirs(sitepath)
+        except Exception:
+            pass

--- a/tests/test_pyexe.py
+++ b/tests/test_pyexe.py
@@ -496,3 +496,13 @@ def testPythonCaseOK(exepath, pyversion):
                             env={'PYTHONCASEOK': 'true'})
         assert 'mixed CASE' not in out
         assert 'No module named' in err
+
+
+def testImportFromExePath(exepath):
+    modpath = os.path.join(os.path.dirname(exepath), 'mod_abc.py')
+    try:
+        open(modpath, 'wt').write('foo = "bar"')
+        out, err = runPyExe(exepath, ['-c', 'import mod_abc;print(mod_abc.foo)'])
+        assert 'bar' in out
+    finally:
+        os.unlink(modpath)


### PR DESCRIPTION
This allows modules in the same directory as the executable to be used.

This resolves #22.