### PR TITLE
bugfix: using ctypes leads to an exception and premature script exit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,6 +78,8 @@ build_script:
   # Patch the PyInstaller building\utils.py to avoid storing project path
   # names.
   - "pushd %PYTHON%\\Lib\\site-packages\\PyInstaller\\building && python -m patch %PROJDIR%\\hooks\\utils.py.diff && popd"
+  # Patch the PyInstall loader\pyiboot01_bootstrap.py to keep ctypes' patches a scope other than global
+  - "pushd %PYTHON%\\Lib\\site-packages\\PyInstaller\\loader && python -m patch %PROJDIR%\\hooks\\pyiboot01_bootstrap.py.diff && popd"
   - del /S /Q %PYTHON%\*.pyc >NUL
   - del /S /Q %PYTHON%\*.pyo >NUL
   # Save the artifact immediately

--- a/hooks/pyiboot01_bootstrap.py.diff
+++ b/hooks/pyiboot01_bootstrap.py.diff
@@ -8,7 +8,7 @@
 +def _setup_ctypes():
      import ctypes
      import os
-+     import sys
++    import sys
      from ctypes import LibraryLoader, DEFAULT_MODE
 -
 +    

--- a/hooks/pyiboot01_bootstrap.py.diff
+++ b/hooks/pyiboot01_bootstrap.py.diff
@@ -1,0 +1,32 @@
+--- pyiboot01_bootstrap.py	2019-08-12 17:37:25.460219000 +1000
++++ pyiboot01_bootstrap.py	2019-08-13 18:10:32.084968800 +1000
+@@ -123,11 +123,11 @@
+ if sys.warnoptions:
+     import warnings
+ 
+-try:
++def _setup_ctypes():
+     import ctypes
+     import os
+     from ctypes import LibraryLoader, DEFAULT_MODE
+-
++    
+     def _frozen_name(name):
+         if name:
+             frozen_name = os.path.join(sys._MEIPASS, os.path.basename(name))
+@@ -186,6 +186,8 @@
+ 
+         ctypes.OleDLL = PyInstallerOleDLL
+         ctypes.oledll = LibraryLoader(PyInstallerOleDLL)
++try:
++    _setup_ctypes()
+ except ImportError:
+     pass
+ 
+@@ -213,4 +215,4 @@
+ # use-case, see issue #653.
+ if os.path.isdir(d):
+     for fn in os.listdir(d):
+-        sys.path.append(os.path.join(d, fn))
++        sys.path.append(os.path.join(d, fn)) 
+\ No newline at end of file

--- a/hooks/pyiboot01_bootstrap.py.diff
+++ b/hooks/pyiboot01_bootstrap.py.diff
@@ -1,6 +1,6 @@
 --- pyiboot01_bootstrap.py	2019-08-12 17:37:25.460219000 +1000
 +++ pyiboot01_bootstrap.py	2019-08-13 18:10:32.084968800 +1000
-@@ -123,11 +123,11 @@
+@@ -123,11 +123,12 @@
  if sys.warnoptions:
      import warnings
  
@@ -8,6 +8,7 @@
 +def _setup_ctypes():
      import ctypes
      import os
++     import sys
      from ctypes import LibraryLoader, DEFAULT_MODE
 -
 +    

--- a/pyexe.py
+++ b/pyexe.py
@@ -408,7 +408,7 @@ PYTHONCASEOK : ignore case in 'import' statements (Windows).""")
     # Generate the globals/locals environment
     globenv = {}
     for key in list(globals().keys()):
-        if key.startswith('_') and key != '_frozen_name':
+        if key.startswith('_') and not key in ['_frozen_name','_setup_ctypes']:
             globenv[key] = globals()[key]
     if RunFile:
         run_file(RunFile, RunFileArgv, SkipFirstLine, globenv)


### PR DESCRIPTION
This PR is fixing a conflict between the scope of variables in PyInstaller's loader (pyiboot01_bootstrap.py) and Pyexe's tweaking of the globals() dictionary.

The problem can be re-produced by the following python script:
import platform
print(platform.system())

which yields the following (on python 2.7):
Traceback (most recent call last):
  File "pyexe.py", line 1236, in <module>
  File "pyexe.py", line 1187, in main
  File "pyexe.py", line 910, in run_file
  File "site-packages\six.py", line 709, in exec_
  File "<string>", line 1, in <module>
  File "<string>", line 6, in <module>
  File "platform.py", line 1265, in system
  File "platform.py", line 1161, in uname
  File "platform.py", line 637, in win32_ver
  File "platform.py", line 592, in _get_real_winver
  File "site-packages\PyInstaller\loader\pyiboot01_bootstrap.py", line 170, in __init__
NameError: global name '_frozen_name' is not defined
[13452] Failed to execute script pyexe

The problem arises because pyiboot01_bootstrap lazy/late binds variables from the global context (for example: _frozen_name() and imports, such as os).  In pyexe.py, all of these variables are then removed from the globals() dictionary (in run_file()), so when some code uses ctypes.WinDLL (which is patched by pyiboot01_bootstrap), these variables cannot be resolved and an exception is emitted.
The simple fix to the problem is to encapsulate all of the relevant code to ctypes in pyiboot01_bootstrap inside a function, to avoid binding to the global context.
